### PR TITLE
Platform: Increase property search connection timeout

### DIFF
--- a/lib/ht/search_client/connection.rb
+++ b/lib/ht/search_client/connection.rb
@@ -32,7 +32,7 @@ module Ht::SearchClient
         conn.request    :url_encoded
         conn.adapter    Faraday.default_adapter
         conn.basic_auth username, password
-        conn.options[:timeout] = 4
+        conn.options[:timeout] = 10
         conn.headers['Accept'] = "application/hal+json;v=#{API_VERSION}"
       end
     end

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.7'
+    VERSION = '1.8'
   end
 end


### PR DESCRIPTION
Some country level dated searches with number of properties > 20K, like france, is currently breaking on PSS, hence we are increasing the timeout for now before we optimise it further.
