### PR TITLE
Platform: Add excluding_ids to Ht::Search::Client remote classes [#86599298]

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ All filters are optional. The filters you can apply are based on:
 - `price_min [integer]`
 - `price_max [integer]`
 - `currency [string] [default: 'EUR']`
+- `excluding_ids [array]`
 
 ### Aggregations
 

--- a/lib/ht/search_client/remote.rb
+++ b/lib/ht/search_client/remote.rb
@@ -8,17 +8,20 @@ module Ht::SearchClient
   #
   class Remote
     ALLOWED_PARAMS = [
-      :order, :per_page, :types, :features, :bedrooms, :page,
-      :guests, :price_min, :price_max, :currency, :aggregations, :range_aggregations
+      :order, :per_page, :types, :features,
+      :bedrooms, :page, :guests, :price_min,
+      :price_max, :currency, :aggregations, :range_aggregations,
+      :excluding_ids
     ].freeze
 
     def initialize(raw_params = {})
-      @raw_params = raw_params
+      @raw_params = raw_params.tap do |params|
+        params[:excluding_ids] = params[:excluding_ids].join(',') if params.has_key?(:excluding_ids)
+      end
     end
 
     def perform
       return search unless block_given?
-
       yield search
     end
 

--- a/spec/lib/ht/search_client/remote_spec.rb
+++ b/spec/lib/ht/search_client/remote_spec.rb
@@ -85,6 +85,16 @@ describe Ht::SearchClient::Remote do
         end
       end
 
+      context 'with excluding ids' do
+        let(:params)      { { excluding_ids: [10, 40, 50] } }
+        let(:request_url) { 'http://username:password@test.com/foo?excluding_ids=10,40,50&per_page=32&page=1&currency=EUR&order=sqs_score' }
+
+        it 'adds the ids to the request url' do
+          subject.perform
+          expect(stub_request :get, request_url).to have_been_requested
+        end
+      end
+
       context 'when currency is different' do
         let(:params)      { { currency: 'USD' } }
         let(:request_url) { 'http://username:password@test.com/foo?per_page=32&page=1&currency=USD&order=sqs_score' }


### PR DESCRIPTION
This enables consumers of the property search to pass an option `excluding_ids` to exclude certain properties from any search endpoint.