### PR TITLE
Expose allowed params

### DIFF
--- a/lib/ht/search_client/remote.rb
+++ b/lib/ht/search_client/remote.rb
@@ -45,6 +45,10 @@ module Ht::SearchClient
       search.fetch('aggregations') { nil }
     end
 
+    def params
+      @params ||= default_options.merge(search_options).freeze
+    end
+
     protected
 
     attr_reader :raw_params
@@ -62,11 +66,6 @@ module Ht::SearchClient
       }
     end
 
-    def params
-      default_options.merge(
-        search_options
-      )
-    end
 
     # NOTE: Developer Sanity announcement this method is
     # being overriden by StaySearch

--- a/spec/lib/ht/search_client/remote_spec.rb
+++ b/spec/lib/ht/search_client/remote_spec.rb
@@ -106,6 +106,20 @@ describe Ht::SearchClient::Remote do
       end
     end
 
+    describe 'params' do
+
+      let(:params) { { page: 1, foo: :bar } }
+      let(:body)   { { 'results' => [] } }
+
+      it 'returns the accepted params' do
+        expect(subject.params).to have_key(:page)
+      end
+
+      it 'does not return disallowed params' do
+        expect(subject.params).to_not have_key(:foo)
+      end
+    end
+
     describe 'result attributes accessors' do
       let(:body) do
         {


### PR DESCRIPTION
This allows to access the params that will be sent to the PSS and might be handy for scenarios where the Remote class need to act as Form objects: `Search.new(options).params[:guests]`