### PR TITLE
Affiliate App: Transform Property ID search into POST requests [#87706892]

### DIFF
--- a/lib/ht/search_client/connection.rb
+++ b/lib/ht/search_client/connection.rb
@@ -9,15 +9,23 @@ module Ht::SearchClient
     class UnknownServerError < StandardError; end
 
     def get(path, params)
-      monitor.notify('attempts')
+      fetch(path, params, :get)
+    end
 
-      with_error_handling(path, params) do
-        @response = client.get(path, params)
-        assert_valid_response
-      end
+    def post(path, params)
+      fetch(path, params, :post)
     end
 
     private
+
+    def fetch(path, params, method)
+      monitor.notify('attempts')
+
+      with_error_handling(path, params) do
+        @response = client.public_send(method, path, params)
+        assert_valid_response
+      end
+    end
 
     def monitor
       Ht::SearchClient.monitor

--- a/lib/ht/search_client/property_ids_stay_search.rb
+++ b/lib/ht/search_client/property_ids_stay_search.rb
@@ -72,12 +72,18 @@ module Ht::SearchClient
     end
 
     def allowed_params
-      super + [:property_ids, :from, :to]
+      super + [:property_ids]
     end
 
     def property_ids
       raw_params.fetch(:property_ids).join(',')
     end
 
+    def search
+      validate_date_params!
+      fix_date_format!
+
+      @search ||= connection.post(endpoint, params)
+    end
   end
 end

--- a/lib/ht/search_client/test.rb
+++ b/lib/ht/search_client/test.rb
@@ -4,11 +4,20 @@ module Ht::SearchClient::Test
     def stub_request(params = {})
       new(params).stub_request
     end
+
+    def stub_post_request(params = {})
+      new(params).stub_post_request
+    end
   end
 
   refine Ht::SearchClient::Remote do
     def stub_request
       @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params)
+      self
+    end
+
+    def stub_post_request
+      @webmock = Ht::SearchClient::Connection.stub_post_request(endpoint, params)
       self
     end
 
@@ -79,6 +88,10 @@ module Ht::SearchClient::Test
     def stub_request(*args)
       new.stub_request(*args)
     end
+
+    def stub_post_request(*args)
+      new.stub_post_request(*args)
+    end
   end
 
   refine Ht::SearchClient::Connection do
@@ -88,6 +101,14 @@ module Ht::SearchClient::Test
       service_uri.password = password
 
       WebMock.stub_request(:get, service_uri.to_s)
+    end
+
+    def stub_post_request(endpoint, params)
+      service_uri          = client.build_url(endpoint)
+      service_uri.user     = username
+      service_uri.password = password
+
+      WebMock.stub_request(:post, service_uri.to_s).with(params)
     end
   end
 

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.12.0'
+    VERSION = '1.12.1'
   end
 end

--- a/spec/lib/ht/search_client/property_ids_stay_search_spec.rb
+++ b/spec/lib/ht/search_client/property_ids_stay_search_spec.rb
@@ -10,7 +10,7 @@ describe Ht::SearchClient::PropertyIdsStaySearch do
   describe '#perform' do
     before do
       Ht::SearchClient::PropertyIdsStaySearch
-        .stub_request(options)
+        .stub_post_request(options)
         .with_results(properties: [
           { 'property_id' => 121, 'average_price' => 121.21 },
           { 'property_id' => 122, 'average_price' => 321.09 }


### PR DESCRIPTION
The amount of property ids passed to the endpoint could exceed the thousand, so we need to use a POST call, as GET's will result in 414s (Request too long).