### PR TITLE
Affiliate App: Update PSS search client gem to send Property IDs in POST requests [#88025854]

### DIFF
--- a/lib/ht/search_client/connection.rb
+++ b/lib/ht/search_client/connection.rb
@@ -9,15 +9,23 @@ module Ht::SearchClient
     class UnknownServerError < StandardError; end
 
     def get(path, params)
-      monitor.notify('attempts')
+      fetch(path, params, :get)
+    end
 
-      with_error_handling(path, params) do
-        @response = client.get(path, params)
-        assert_valid_response
-      end
+    def post(path, params)
+      fetch(path, params, :post)
     end
 
     private
+
+    def fetch(path, params, method = :get)
+      monitor.notify('attempts')
+
+      with_error_handling(path, params) do
+        @response = client.public_send(method, path, params)
+        assert_valid_response
+      end
+    end
 
     def monitor
       Ht::SearchClient.monitor

--- a/lib/ht/search_client/property_ids_stay_search.rb
+++ b/lib/ht/search_client/property_ids_stay_search.rb
@@ -69,6 +69,10 @@ module Ht::SearchClient
   class PropertyIdsStaySearch < Remote
     include StaySearch
 
+    def method
+      :post
+    end
+
     private
 
     def endpoint

--- a/lib/ht/search_client/property_ids_stay_search.rb
+++ b/lib/ht/search_client/property_ids_stay_search.rb
@@ -1,12 +1,20 @@
 module Ht::SearchClient
   #
-  # GET /properties/stays?from=:from&to=:to&property_ids=:property_ids
+  # POST /properties/stays
+  # POST body
+  #   {
+  #     from: '2050-01-01',
+  #     to: '2050-01-01',
+  #     property_ids: '1,2,3,4',
+  #     order: 'sqs_score',
+  #     etc.
+  #   }
   #
   # For a given place and dates, return matching stays
   #
   # Parameters:
   #   Required:
-  #     - :property_ids - ids of properties to be checked, in an array
+  #     - :property_ids - array of properties ids
   #     - :from - the check-in date
   #     - :to - the check-out date
   #   Optional:
@@ -72,12 +80,19 @@ module Ht::SearchClient
     end
 
     def allowed_params
-      super + [:property_ids, :from, :to]
+      super + [:property_ids]
     end
 
     def property_ids
       raw_params.fetch(:property_ids).join(',')
     end
 
+    # this endpoint requires a POST request
+    def search
+      validate_date_params!
+      fix_date_format!
+
+      @search ||= connection.post(endpoint, params)
+    end
   end
 end

--- a/lib/ht/search_client/remote.rb
+++ b/lib/ht/search_client/remote.rb
@@ -49,6 +49,10 @@ module Ht::SearchClient
       @params ||= default_options.merge(search_options).freeze
     end
 
+    def method
+      :get
+    end
+
     protected
 
     attr_reader :raw_params

--- a/lib/ht/search_client/test.rb
+++ b/lib/ht/search_client/test.rb
@@ -1,14 +1,14 @@
 module Ht::SearchClient::Test
 
   refine Ht::SearchClient::Remote.singleton_class do
-    def stub_request(params = {})
-      new(params).stub_request
+    def stub_request(params = {}, method = :get)
+      new(params).stub_request(method)
     end
   end
 
   refine Ht::SearchClient::Remote do
-    def stub_request
-      @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params)
+    def stub_request(method)
+      @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params, method)
       self
     end
 
@@ -82,12 +82,18 @@ module Ht::SearchClient::Test
   end
 
   refine Ht::SearchClient::Connection do
-    def stub_request(endpoint, params)
-      service_uri          = client.build_url(endpoint, params)
+    def stub_request(endpoint, params, method = :get)
+      stubbed_params = if method == :get
+        { query: params }
+      else
+        { body: params }
+      end
+
+      service_uri          = client.build_url(endpoint)
       service_uri.user     = username
       service_uri.password = password
 
-      WebMock.stub_request(:get, service_uri.to_s)
+      WebMock.stub_request(method, service_uri).with(stubbed_params)
     end
   end
 

--- a/lib/ht/search_client/test.rb
+++ b/lib/ht/search_client/test.rb
@@ -1,14 +1,14 @@
 module Ht::SearchClient::Test
 
   refine Ht::SearchClient::Remote.singleton_class do
-    def stub_request(params = {}, method = :get)
-      new(params).stub_request(method)
+    def stub_request(params = {})
+      new(params).stub_request
     end
   end
 
   refine Ht::SearchClient::Remote do
-    def stub_request(method)
-      @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params, method)
+    def stub_request
+      @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params, self.method)
       self
     end
 

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.12.0'
+    VERSION = '1.12.1'
   end
 end

--- a/spec/lib/ht/search_client/connection_spec.rb
+++ b/spec/lib/ht/search_client/connection_spec.rb
@@ -2,10 +2,26 @@ require 'spec_helper'
 
 describe Ht::SearchClient::Connection do
   let(:request_url) { 'http://username:password@test.com/foo' }
-  let(:perform) { subject.get(request_url, {}) }
   let(:monitor) { Ht::SearchClient.monitor }
 
+  describe '#post' do
+    let(:perform) { subject.post(request_url, {}) }
+
+    context 'the request is successful' do
+      before do
+        stub_request(:post, request_url).
+          to_return(status: 200, body: { results: [1, 2, 3] }.to_json, headers: {})
+      end
+
+      it 'should perform a post request' do
+        expect(perform).to have_requested(:post, request_url)
+      end
+    end
+  end
+
   describe '#get' do
+    let(:perform) { subject.get(request_url, {}) }
+
     context 'the request is successful' do
       before do
         stub_request(:get, request_url).

--- a/spec/lib/ht/search_client/property_ids_stay_search_spec.rb
+++ b/spec/lib/ht/search_client/property_ids_stay_search_spec.rb
@@ -3,14 +3,23 @@ require 'spec_helper'
 describe Ht::SearchClient::PropertyIdsStaySearch do
   using Ht::SearchClient::Test
 
-  let(:options) { { property_ids: [121, 122], from: '2020-08-15', to: '2020-08-20' } }
+  let(:options) {
+    {
+      property_ids: [121, 122],
+      from: '2020-08-15',
+      to: '2020-08-20',
+      per_page: '32',
+      page: '1'
+    }
+  }
+
   subject       { described_class.new(options) }
   let(:results) { subject.perform; subject.results }
 
   describe '#perform' do
     before do
       Ht::SearchClient::PropertyIdsStaySearch
-        .stub_request(options)
+        .stub_request(options, :post)
         .with_results(properties: [
           { 'property_id' => 121, 'average_price' => 121.21 },
           { 'property_id' => 122, 'average_price' => 321.09 }
@@ -51,6 +60,5 @@ describe Ht::SearchClient::PropertyIdsStaySearch do
       options.delete(:from)
       expect { subject.perform }.to raise_error(KeyError)
     end
-
   end
 end

--- a/spec/lib/ht/search_client/property_ids_stay_search_spec.rb
+++ b/spec/lib/ht/search_client/property_ids_stay_search_spec.rb
@@ -19,7 +19,7 @@ describe Ht::SearchClient::PropertyIdsStaySearch do
   describe '#perform' do
     before do
       Ht::SearchClient::PropertyIdsStaySearch
-        .stub_request(options, :post)
+        .stub_request(options)
         .with_results(properties: [
           { 'property_id' => 121, 'average_price' => 121.21 },
           { 'property_id' => 122, 'average_price' => 321.09 }


### PR DESCRIPTION
Changes the `properties/stay` endpoint to issue a POST request (rather than a get).  Since [this PR](https://github.com/HouseTrip/property_search/pull/219), the PSS has been updated to allow this (and that change has been deployed to production).

The `stub_request` (helper available in specs) can now take an optional `method` argument.

This new version of the gem has been deployed and tested/working on affiliate app staging.  It is a patch version bump, since only the internals have changed.

@pedrocunha - this PR is similar to the (now closed) #11 from @amencarini, but with a few improvements wrt. your comments. 

===

Pivotal tracker story [#88025854](https://www.pivotaltracker.com/story/show/88025854) in project *Affiliate App*:

> Update the property search service gem to send property_ids and other params in a POST request for the new property_ids endpoint.