### PR TITLE
Accept random and random seed parameters

### DIFF
--- a/ht-search_client.gemspec
+++ b/ht-search_client.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-nav'
   spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'safe_yaml', "~> 1.0.4"
 end

--- a/lib/ht/search_client/remote.rb
+++ b/lib/ht/search_client/remote.rb
@@ -11,7 +11,7 @@ module Ht::SearchClient
       :order, :per_page, :types, :features,
       :bedrooms, :page, :guests, :price_min,
       :price_max, :currency, :aggregations, :range_aggregations,
-      :excluding_ids
+      :excluding_ids, :random, :random_order_seed
     ].freeze
 
     def initialize(raw_params = {})

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.12.1'
+    VERSION = '1.12.2'
   end
 end

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.12.2'
+    VERSION = '1.13'
   end
 end


### PR DESCRIPTION
As part of https://www.pivotaltracker.com/story/show/87797302 I would like to add `random` and `random_order_seed` to the allowed params of the PSS gem

============Story Details===========

### Why
In the context of search results ranking we want to test the performance of the SQS score ordering against a random score ordering. This will tell us how good (or bad) the SQS score is performing.

### What
Make the web app capable of request random properties from the PSS. The user is not aware of the random ordering feature, we simply override the SQS option in the backend. 

The feature is protected by a flag, `srp_with_random_results`

### Testing scenario
* `srp_with_random_results` flag is off
* go to the SRP
* Results are ordered by SQS
* turn the `srp_with_random_results` flag on
* go to the SRP
* Results are randomly ordered
