### PR TITLE
Affiliate App: Revert changing to POST endpoint for PSS/affiliate app ids based search [#88891886]

### DIFF
--- a/lib/ht/search_client/connection.rb
+++ b/lib/ht/search_client/connection.rb
@@ -9,23 +9,15 @@ module Ht::SearchClient
     class UnknownServerError < StandardError; end
 
     def get(path, params)
-      fetch(path, params, :get)
-    end
-
-    def post(path, params)
-      fetch(path, params, :post)
-    end
-
-    private
-
-    def fetch(path, params, method = :get)
       monitor.notify('attempts')
 
       with_error_handling(path, params) do
-        @response = client.public_send(method, path, params)
+        @response = client.get(path, params)
         assert_valid_response
       end
     end
+
+    private
 
     def monitor
       Ht::SearchClient.monitor

--- a/lib/ht/search_client/property_ids_stay_search.rb
+++ b/lib/ht/search_client/property_ids_stay_search.rb
@@ -1,20 +1,12 @@
 module Ht::SearchClient
   #
-  # POST /properties/stays
-  # POST body
-  #   {
-  #     from: '2050-01-01',
-  #     to: '2050-01-01',
-  #     property_ids: '1,2,3,4',
-  #     order: 'sqs_score',
-  #     etc.
-  #   }
+  # GET /properties/stays?from=:from&to=:to&property_ids=:property_ids
   #
   # For a given place and dates, return matching stays
   #
   # Parameters:
   #   Required:
-  #     - :property_ids - array of properties ids
+  #     - :property_ids - array of property ids
   #     - :from - the check-in date
   #     - :to - the check-out date
   #   Optional:
@@ -68,10 +60,6 @@ module Ht::SearchClient
   #
   class PropertyIdsStaySearch < Remote
     include StaySearch
-
-    def method
-      :post
-    end
 
     private
 

--- a/lib/ht/search_client/test.rb
+++ b/lib/ht/search_client/test.rb
@@ -8,7 +8,7 @@ module Ht::SearchClient::Test
 
   refine Ht::SearchClient::Remote do
     def stub_request
-      @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params, self.method)
+      @webmock = Ht::SearchClient::Connection.stub_request(endpoint, params)
       self
     end
 
@@ -82,19 +82,12 @@ module Ht::SearchClient::Test
   end
 
   refine Ht::SearchClient::Connection do
-    def stub_request(endpoint, params, method = :get)
-      stubbed_params = if method == :get
-        { query: params }
-      else
-        { body: params }
-      end
-
+    def stub_request(endpoint, params)
       service_uri          = client.build_url(endpoint)
       service_uri.user     = username
       service_uri.password = password
 
-      WebMock.stub_request(method, service_uri).with(stubbed_params)
+      WebMock.stub_request(:get, service_uri).with(query: params)
     end
   end
-
 end

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.13.1'
+    VERSION = '1.13.2'
   end
 end

--- a/lib/ht/search_client/version.rb
+++ b/lib/ht/search_client/version.rb
@@ -1,5 +1,5 @@
 module Ht
   module SearchClient
-    VERSION = '1.13.2'
+    VERSION = '1.14'
   end
 end

--- a/spec/lib/ht/search_client/connection_spec.rb
+++ b/spec/lib/ht/search_client/connection_spec.rb
@@ -4,21 +4,6 @@ describe Ht::SearchClient::Connection do
   let(:request_url) { 'http://username:password@test.com/foo' }
   let(:monitor) { Ht::SearchClient.monitor }
 
-  describe '#post' do
-    let(:perform) { subject.post(request_url, {}) }
-
-    context 'the request is successful' do
-      before do
-        stub_request(:post, request_url).
-          to_return(status: 200, body: { results: [1, 2, 3] }.to_json, headers: {})
-      end
-
-      it 'should perform a post request' do
-        expect(perform).to have_requested(:post, request_url)
-      end
-    end
-  end
-
   describe '#get' do
     let(:perform) { subject.get(request_url, {}) }
 


### PR DESCRIPTION
Revert to using only GET requests in all PSS endpoints.  This changes the `PropertyIdsStaySearch` to be handled with a GET request (rather than a POST). 

This is now possible since the Affiliate app is limiting the number of IDs passed and keeping the GET request URL within Heroku's limits.

* :rocket: Deployed to http://affiliate-app-staging.herokuapp.com (endpoint tested by Matt)
* :warning: **Please don't merge until ALL tests finish running && MASTER IS ALSO GREEN!**

===

Pivotal tracker story [#88891886](https://www.pivotaltracker.com/story/show/88891886) in project *Affiliate App*:

> Based on feedback from Rumi and after warning 2 affiliates of the change (hundredrooms, idealo)
> 
> We should limit max # property ids in requests to 100 (respond with error if more are passed) and revert to a GET request in;
> 
> * Affiliate app
> * Search client gem
> * PSS app
> 
> (in this order of work/deployment)